### PR TITLE
修复一些Linux下Python调用so的bug

### DIFF
--- a/FD/python/arcsoft/AFD_FSDKLibrary.py
+++ b/FD/python/arcsoft/AFD_FSDKLibrary.py
@@ -32,7 +32,7 @@ AFD_FSDK_FOC_330 = 0xc;  # 330 degree
 if platform.system() == u'Windows':
     internalLibrary = CDLL(u'libarcsoft_fsdk_face_detection.dll')
 else:
-    internalLibrary = CDLL(u'libarcsoft_fsdk_face_detection.so')
+    internalLibrary = CDLL(u'./libarcsoft_fsdk_face_detection.so')
 
 AFD_FSDK_InitialFaceEngine = internalLibrary.AFD_FSDK_InitialFaceEngine
 AFD_FSDK_UninitialFaceEngine = internalLibrary.AFD_FSDK_UninitialFaceEngine

--- a/FD/python/arcsoft/CLibrary.py
+++ b/FD/python/arcsoft/CLibrary.py
@@ -5,7 +5,7 @@ import platform
 if platform.system() == u'Windows':
     internalLibrary = cdll.msvcrt
 else:
-    internalLibrary = CDLL(u'libc.so')
+    internalLibrary = CDLL(u'libc.so.6')
 
 malloc = internalLibrary.malloc
 free = internalLibrary.free

--- a/FR/python/arcsoft/AFD_FSDKLibrary.py
+++ b/FR/python/arcsoft/AFD_FSDKLibrary.py
@@ -32,7 +32,7 @@ AFD_FSDK_FOC_330 = 0xc;  # 330 degree
 if platform.system() == u'Windows':
     internalLibrary = CDLL(u'libarcsoft_fsdk_face_detection.dll')
 else:
-    internalLibrary = CDLL(u'libarcsoft_fsdk_face_detection.so')
+    internalLibrary = CDLL(u'./libarcsoft_fsdk_face_detection.so')
 
 AFD_FSDK_InitialFaceEngine = internalLibrary.AFD_FSDK_InitialFaceEngine
 AFD_FSDK_UninitialFaceEngine = internalLibrary.AFD_FSDK_UninitialFaceEngine

--- a/FR/python/arcsoft/AFR_FSDKLibrary.py
+++ b/FR/python/arcsoft/AFR_FSDKLibrary.py
@@ -55,7 +55,7 @@ class AFR_FSDK_FACEMODEL(Structure):
 if platform.system() == u'Windows':
     internalLibrary = CDLL(u'libarcsoft_fsdk_face_recognition.dll')
 else:
-    internalLibrary = CDLL(u'libarcsoft_fsdk_face_recognition.so')
+    internalLibrary = CDLL(u'./libarcsoft_fsdk_face_recognition.so')
 
 AFR_FSDK_InitialEngine = internalLibrary.AFR_FSDK_InitialEngine
 AFR_FSDK_UninitialEngine = internalLibrary.AFR_FSDK_UninitialEngine

--- a/FR/python/arcsoft/CLibrary.py
+++ b/FR/python/arcsoft/CLibrary.py
@@ -5,7 +5,7 @@ import platform
 if platform.system() == u'Windows':
     internalLibrary = cdll.msvcrt
 else:
-    internalLibrary = CDLL(u'libc.so')
+    internalLibrary = CDLL(u'libc.so.6')
 
 malloc = internalLibrary.malloc
 free = internalLibrary.free


### PR DESCRIPTION
执行`internalLibrary = CDLL(u'libc.so')`时可能会出现错误`python3 OSError: /lib64/libc.so: invalid ELF header`。

可改为`internalLibrary = CDLL(u'libc.so.6')`。